### PR TITLE
change default get behavior

### DIFF
--- a/workflows_core/config.py
+++ b/workflows_core/config.py
@@ -71,7 +71,10 @@ class BaseConfig(BaseModel):
         configs
         """
         if hasattr(self, value):
-            return getattr(self, value)
+            return_value = getattr(self, value)
+            if return_value is None:
+                return default
+            return return_value
         else:
             return default
 


### PR DESCRIPTION
it resolves the issue we talked about earlier.
Let's say for backwards compatibility we allow None to be default for pydantic .
if we do this:
config.get("vec_alias", "default")

This will return None

However - with this PR:
config.get("vec_alias", "default")

will return default